### PR TITLE
Fixed links to Google whitepapers

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,17 +66,17 @@
 <p>Current "rocket science" in distributed systems.</p>
 
 <ul>
-<li><a href="http://labs.google.com/papers/mapreduce.html">MapReduce</a></li>
+<li><a href="http://research.google.com/archive/mapreduce.html">MapReduce</a></li>
 
-<li><a href="http://labs.google.com/papers/chubby.html">Chubby Lock Manager</a></li>
+<li><a href="http://research.google.com/archive/chubby.html">Chubby Lock Manager</a></li>
 
-<li><a href="http://labs.google.com/papers/gfs.html">Google File System</a></li>
+<li><a href="http://research.google.com/archive/gfs.html">Google File System</a></li>
 
-<li><a href="http://labs.google.com/papers/bigtable.html">BigTable</a></li>
+<li><a href="http://research.google.com/archive/bigtable.html">BigTable</a></li>
 
 <li><a href="http://www.usenix.org/event/worlds06/tech/prelim_papers/perl/perl.pdf">Data Management for Internet-Scale Single-Sign-On</a></li>
-<li><a href="http://www.google.com/research/pubs/pub36632.html">Dremel: Interactive Analysis of Web-Scale Datasets</a></li>
-<li><a href="http://www.google.com/research/pubs/pub36726.html">Large-scale Incremental Processing Using Distributed Transactions and Notifications</a></li>
+<li><a href="http://research.google.com/pubs/pub36632.html">Dremel: Interactive Analysis of Web-Scale Datasets</a></li>
+<li><a href="http://research.google.com/pubs/pub36726.html">Large-scale Incremental Processing Using Distributed Transactions and Notifications</a></li>
 <li><a href="http://www.cidrdb.org/cidr2011/Papers/CIDR11_Paper32.pdf">Megastore: Providing Scalable, Highly Available Storage for Interactive Services</a> - Smart design for low latency Paxos implementation across datacentres.</li>
 <li><a href="http://research.google.com/archive/spanner.html">Spanner</a> - Google's scalable, multi-version, globally-distributed, and synchronously-replicated database.</li>
 <li><a href="http://research.google.com/pubs/pub41318.html">Photon</a> -  Fault-tolerant and Scalable Joining of Continuous Data Streams. Joins are tough especially with time-skew, high availability and distribution.</li>


### PR DESCRIPTION
Google apparently practiced some bad SEO and moved some files around without redirects. Updated labs.google.com/\* and www.google.com/research/* to research.google.com/archives/\1 and research.google.com/\2, respectively.
